### PR TITLE
Chore: Local server port and start options.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   # Run the "check" script only once.
   - 'if [ "$ROWDY_CHECK" ]; then npm run check; else true; fi'
   # Try a different port!
-  - 'if [ "$ROWDY_CHECK" ]; then ROWDY_OPTIONS='{ "client":{ "logger":true }, "server":{ "logger":true,"port":4321 } }' npm run test; else true; fi'
+  - 'if [ "$ROWDY_CHECK" ]; then ROWDY_OPTIONS="{ \"client\":{ \"logger\":true }, \"server\":{ \"logger\":true,\"port\":4321 } }" npm run test; else true; fi'
 
   # Different matrix of settings
   - '[ "$ROWDY_CHECK" ] || npm test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,8 @@ before_script:
 script:
   # Run the "check" script only once.
   - 'if [ "$ROWDY_CHECK" ]; then npm run check; else true; fi'
+  # Try a different port!
+  - 'if [ "$ROWDY_CHECK" ]; then ROWDY_OPTIONS='{ "client":{ "logger":true }, "server":{ "logger":true,"port":4321 } }' npm run test; else true; fi'
+
+  # Different matrix of settings
   - '[ "$ROWDY_CHECK" ] || npm test'

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
 History
 =======
 
+## Current
+* Add configurable server/client `port` option.
+
 ## 0.3.0
 * **Breaking Changes**: Configuration `options` structure has changed.
 * Use [`guacamole`](https://github.com/testarmada/guacamole) for Sauce Labs

--- a/README.md
+++ b/README.md
@@ -95,6 +95,31 @@ var config = require("./PATH/TO/config");
 var rowdy = require("rowdy")(config);
 ```
 
+### Local Examples
+
+Start the local Selenium server on a different port:
+
+```
+$ ROWDY_OPTIONS='{ "server": { "port":4321 } }' \
+  npm run test
+```
+
+Have client hit an already running local Selenium server without starting its
+own:
+
+```
+# In one terminal
+$  java -jar node_modules/selenium-standalone/.selenium/selenium-server/2.45.0-server.jar \
+   -port 4321 \
+   -Dphantomjs.binary.path=node_modules/phantomjs/lib/phantom/bin/phantomjs
+
+# In another...
+$ ROWDY_OPTIONS='{ "client": { "port":4321 }, "server": { "start":false } }' \
+  npm run test
+```
+
+
+
 ### Sauce Labs + Guacamole
 
 We use [guacamole](https://github.com/testarmada/guacamole) to have

--- a/README.md
+++ b/README.md
@@ -118,8 +118,6 @@ $ ROWDY_OPTIONS='{ "client": { "port":4321 }, "server": { "start":false } }' \
   npm run test
 ```
 
-
-
 ### Sauce Labs + Guacamole
 
 We use [guacamole](https://github.com/testarmada/guacamole) to have

--- a/config.js
+++ b/config.js
@@ -58,13 +58,20 @@ module.exports = {
    */
   options: {
     client: {
-      logger: false
+      logger: false,
+      port: null                // Selenium port to hit.
     },
     server: {
       logger: false,
       debug: false,
+      port: null,               // Selenium port to start on.
       startTimeout: 10 * 1000,  // Max wait for local server to start (ms).
       stopTimeout: 10 * 1000    // Max wait for local server to stop (ms).
+
+      // Implied Overrides
+      // -----------------
+      // start: true,
+      // phantomPath: PHANTOM_PATH
     },
     guacamole: {
       // Use https://github.com/testarmada/guacamole settings?
@@ -100,6 +107,7 @@ module.exports = {
         desiredCapabilities: {
           browserName: "phantomjs"
         },
+        // These options _can_ be overriden from environment options.
         server: {
           start: true,
           phantomPath: PHANTOM_PATH

--- a/lib/client/base.js
+++ b/lib/client/base.js
@@ -1,6 +1,7 @@
 /**
  * Abstract base client (browser) wrapper.
  */
+var _ = require("lodash");
 var log = require("../log");
 
 /**
@@ -16,11 +17,6 @@ var Client = module.exports = function (config) {
 
   // Init member variables, stash config.
   this._config = config;
-
-  // Set up extra logging.
-  if (config.options.client.logger) {
-    this._addLogger();
-  }
 };
 
 Object.defineProperty(Client.prototype, "selClient", {
@@ -42,6 +38,34 @@ Client.prototype.log = log.bind(log, "[CLIENT]".green);
  * Add a logger to stdout.
  */
 Client.prototype._addLogger = function () {};
+
+/**
+ * Return `remote` object for selenium session.
+ *
+ * Order of precedence:
+ * - Explicit `remote: { port: 1234 }`
+ * - `options: { client: { port: 1234 } }`
+ * - `options: { server: { port: 1234 } }` if local server is running.
+ *
+ * @param   {Object} config Configuration object
+ * @returns {Object}        Remove object
+ */
+Client.prototype._getRemote = function (config) {
+  var remote = _.cloneDeep(config.setting.remote || {});
+
+  // An explicit `remote` object wins.
+  // Otherwise, override with `client` option.
+  if (!remote.port && config.options.client.port) {
+    remote.port = config.options.client.port;
+  }
+  // Otherwise, fallback to `server` option if running server.
+  if (!remote.port && config.setting.server.start &&
+      config.options.server.port) {
+    remote.port = config.options.server.port;
+  }
+
+  return remote;
+};
 
 /**
  * Initialize underlying client with capabilities.

--- a/lib/client/impl/wd.js
+++ b/lib/client/impl/wd.js
@@ -11,7 +11,7 @@ var Client = module.exports = function (config) {
   var wd = require("wd");
 
   // Set up a client with `remote` configuration.
-  this._selClient = wd.promiseChainRemote(config.setting.remote || {});
+  this._selClient = wd.promiseChainRemote(this._getRemote(config));
 
   // Apply base _last_ because we need `this.client` setup first.
   Base.apply(this, arguments);

--- a/lib/client/impl/webdriverio.js
+++ b/lib/client/impl/webdriverio.js
@@ -11,7 +11,7 @@ var Client = module.exports = function (config) {
   var webdriverio = require("webdriverio");
 
   // Set up a client with `remote` configuration.
-  this._selClient = webdriverio.remote(config.setting.remote || {});
+  this._selClient = webdriverio.remote(this._getRemote(config));
   this._sessionID = null;
 
   // Apply base _last_ because we need `this._selClient` setup first.

--- a/lib/config.js
+++ b/lib/config.js
@@ -79,11 +79,13 @@ var DEFAULTS = {
    */
   options: {
     client: {
-      logger: false
+      logger: false,
+      port: null                // Selenium port to hit.
     },
     server: {
       logger: false,
       debug: false,
+      port: null,               // Selenium port to start on.
       startTimeout: 10 * 1000,  // Max wait for local server to start (ms).
       stopTimeout: 10 * 1000    // Max wait for local server to stop (ms).
     },
@@ -108,8 +110,9 @@ var getGuacamole = _.memoize(function () {
   }
 });
 
-// TODO: Refactor and decompose out the `max-statements` warning.
-/*eslint-disable max-statements*/
+// TODO: Refactor and decompose out the `max-statements`, `complexity` warnings.
+// https://github.com/FormidableLabs/rowdy/issues/29
+/*eslint-disable max-statements,complexity*/
 module.exports = function (cfg) {
   // Merge config.
   cfg = _.cloneDeep(_.merge({}, DEFAULTS, cfg));
@@ -207,6 +210,16 @@ module.exports = function (cfg) {
     return memo[key];
   }, cfg.settings);
 
+  // Last overrides from options.
+  if (!_.isUndefined(cfg.options.server.start)) {
+    cfg.settings.server = cfg.settings.server || {};
+    cfg.settings.server.start = cfg.options.server.start;
+  }
+  if (!_.isUndefined(cfg.options.server.phantomPath)) {
+    cfg.settings.server = cfg.settings.server || {};
+    cfg.settings.server.phantomPath = cfg.options.server.phantomPath;
+  }
+
   return cfg;
 };
-/*eslint-enable max-statements*/
+/*eslint-enable max-statements,complexity*/

--- a/lib/server.js
+++ b/lib/server.js
@@ -81,6 +81,7 @@ Server.prototype.start = function (callback) {
   callback = callback || function () {};
 
   var self = this;
+  var port = self.config.options.server.port;
   var doLog = self.config.options.server.logger;
   var debug = self.config.options.server.debug;
   var startTimeout = self.config.options.server.startTimeout;
@@ -103,6 +104,7 @@ Server.prototype.start = function (callback) {
   // Start selenium process.
   selenium.start({
     seleniumArgs: [].concat(
+      port ? ["-port", port] : [],
       debug ? ["-debug"] : [],
       phantomPath ? ["-Dphantomjs.binary.path=" + phantomPath] : []
     ),


### PR DESCRIPTION
Adds some new options:

* `server.start` exposed to `ROWDY_OPTIONS`
* `server.port`, `client.port` exposed to `ROWDY_OPTIONS`
* Add some new use cases to README

/cc @Maciek416 