### PR TITLE
Support sauce connect tunnel identifiers / Update Guacamole for Synchronous Operation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,12 @@ env:
     - ROWDY_SETTINGS="sauceLabs.IE_10_Windows_2012_Desktop"
     - ROWDY_SETTINGS="sauceLabs.IE_11_Windows_2012_R2_Desktop"
     # BrowserStack
-    - ROWDY_SETTINGS="browserStack.safari-mac"
-    - ROWDY_SETTINGS="browserStack.chrome-win7"
+    #
+    # Disable BS until "The environment you requested was unavailable." errors
+    # are figured out and/or subside.
+    # https://github.com/FormidableLabs/rowdy/issues/34
+    #- ROWDY_SETTINGS="browserStack.safari-mac"
+    #- ROWDY_SETTINGS="browserStack.chrome-win7"
 
 before_script:
   # Download selenium drivers.

--- a/lib/config.js
+++ b/lib/config.js
@@ -192,10 +192,10 @@ module.exports = function (cfg) {
 
   if (cfg.settings.sauceLabs && SAUCE_CONNECT_TUNNEL_ID) {
     // Mutate all capabilities with tunnel identifier if present.
-    _.each(cfg.settings.sauceLabs, function (obj, objKey) {
+    _.each(cfg.settings.sauceLabs, function (obj) {
       obj.desiredCapabilities = obj.desiredCapabilities || {};
       obj.desiredCapabilities.tunnelIdentifier = SAUCE_CONNECT_TUNNEL_ID;
-    });  
+    });
   }
 
   // --------------------------------------------------------------------------

--- a/lib/config.js
+++ b/lib/config.js
@@ -190,16 +190,12 @@ module.exports = function (cfg) {
   // Tunnel Setup (SauceConnect): Add tunnel settings to all browser configs.
   // --------------------------------------------------------------------------
 
-  if (SAUCE_CONNECT_TUNNEL_ID) {
-    if (cfg.settings.sauceLabs) {
-      _.each(cfg.settings.sauceLabs, function (obj, objKey) {
-        if (!cfg.settings.sauceLabs[objKey].desiredCapabilities) {
-          cfg.settings.sauceLabs[objKey].desiredCapabilities = {};
-        }
-        var caps = cfg.settings.sauceLabs[objKey].desiredCapabilities;
-        caps.tunnelIdentifier = SAUCE_CONNECT_TUNNEL_ID;
-      });
-    }
+  if (cfg.settings.sauceLabs && SAUCE_CONNECT_TUNNEL_ID) {
+    // Mutate all capabilities with tunnel identifier if present.
+    _.each(cfg.settings.sauceLabs, function (obj, objKey) {
+      obj.desiredCapabilities = obj.desiredCapabilities || {};
+      obj.desiredCapabilities.tunnelIdentifier = SAUCE_CONNECT_TUNNEL_ID;
+    });  
   }
 
   // --------------------------------------------------------------------------

--- a/lib/config.js
+++ b/lib/config.js
@@ -38,6 +38,7 @@ var _ = require("lodash");
 
 var ROWDY_SETTINGS = process.env.ROWDY_SETTINGS || "";
 var ROWDY_OPTIONS = process.env.ROWDY_OPTIONS || "{}";
+var SAUCE_CONNECT_TUNNEL_ID = process.env.SAUCE_CONNECT_TUNNEL_ID;
 var QUOTES_RE = /^[\s\\\'\"]*|[\s\\\'\"]*$/g;
 
 /**
@@ -152,7 +153,18 @@ module.exports = function (cfg) {
     // SauceLabs.
     // Require guacamole to be installed to actually add capabilities.
     if (guacamole && settingsPath[0] === "sauceLabs") {
-      guacamole.useShrinkwrap(cfg.options.guacamole.shrinkwrap);
+      try {
+        // Attempt to use a shrinkwrap. If that fails, sync-fetch from Sauce.
+        guacamole.useShrinkwrap(cfg.options.guacamole.shrinkwrap);
+      } catch (readErr) {
+        try {
+          guacamole.useServiceSync();
+        } catch (fetchErr) {
+          throw new Error("Exhausted attempts to fetch sauce browser info:\n"
+            + "Couldn't read local shinkwrap: " + readErr.toString() + "\n"
+            + "Couldn't GET remote sauce data: " + fetchErr.toString());
+        }
+      }
 
       var browserId = settingsPath[1];
       var matchingCapabilities = guacamole.get({ id: browserId });
@@ -172,6 +184,22 @@ module.exports = function (cfg) {
     // BrowserStack
     // TODO: Add BS support when it lands in guacamole.
     // https://github.com/FormidableLabs/rowdy/issues/26
+  }
+
+  // --------------------------------------------------------------------------
+  // Tunnel Setup (SauceConnect): Add tunnel settings to all browser configs.
+  // --------------------------------------------------------------------------
+
+  if (SAUCE_CONNECT_TUNNEL_ID) {
+    if (cfg.settings.sauceLabs) {
+      _.each(cfg.settings.sauceLabs, function (obj, objKey) {
+        if (!cfg.settings.sauceLabs[objKey].desiredCapabilities) {
+          cfg.settings.sauceLabs[objKey].desiredCapabilities = {};
+        }
+        var caps = cfg.settings.sauceLabs[objKey].desiredCapabilities;
+        caps.tunnelIdentifier = SAUCE_CONNECT_TUNNEL_ID;
+      });
+    }
   }
 
   // --------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "phantomjs": "^1.9.16",
     "saucelabs": "^0.1.1",
     "selenium-standalone": "^4.4.0",
-    "guacamole": "^1.0.9",
+    "guacamole": "^1.1.2",
     "wd": "^0.3.11",
     "webdriverio": "^2.4.5"
   },


### PR DESCRIPTION
This PR:
  - Has rowdy make use of `SAUCE_CONNECT_TUNNEL_ID` from the environment, if it exists. If supplied, rowdy will add `tunnelIdentifier` to all the `sauceLabs` `desiredCapabilities` objects found in the configuration.
  - Updates `guacamole` for synchronous operation update.
  - If using `guacamole`, use shrinkwrap. If the shrinkwrap load fails, try fetching synchronously from the SauceLabs API platform endpoint.

/cc @ryan-roemer 