### PR TITLE
Chore: kill, Kill, KILL the selenium process with tree-kill.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -4,6 +4,7 @@
  * Wrap up a selenium server process.
  */
 var _ = require("lodash");
+var treeKill = require("tree-kill");
 var log = require("./log");
 var _log = log.bind(log, "[SERVER]".yellow);
 var NOT_FOUND = -1;
@@ -207,8 +208,12 @@ Server.prototype.stop = function (callback) {
     self._err = codeOrErr instanceof Error ? codeOrErr : self._err;
     callback(self._err);
   });
-
   proc.on("exit", _done);
+
+  // Kill it the "official" way.
   proc.kill();
+
+  // Kill it the unofficial way.
+  treeKill(proc.pid, "SIGKILL", _done);
 };
 /*eslint-enable max-statements*/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "colors": "1.1.0",
     "lodash": "3.8.0",
-    "portscanner": "^1.0.0"
+    "portscanner": "^1.0.0",
+    "tree-kill": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
Uses additional `tree-kill` with `SIGKILL` to nuke Selenium.

/cc @coopy @kkerr1 