### PR TITLE
BUG: Require modern webdriverio and fix updated end() api call.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ $ npm install --save-dev webdriverio saucelabs
 _Note_: If using SauceLabs + WebdriverIO, we lazy `require` the Sauce Labs
 module to upload results of "done" to your SL account.
 
+_Note_: Rowdy requires `webdriverio` at version `v3.0.0` or above.
+
 #### Sauce Labs
 
 If you intend to use Sauce Labs +

--- a/lib/client/impl/webdriverio.js
+++ b/lib/client/impl/webdriverio.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var inherits = require("util").inherits;
+var _ = require("lodash");
 var Base = require("../base");
 
 /**
@@ -69,7 +70,21 @@ Client.prototype.init = function (caps, callback) {
  * @returns {void}
  */
 Client.prototype.quit = function (callback) {
-  this._selClient.end(callback);
+  callback = _.once(callback);
+  var self = this;
+
+  // The signature of `.end()` changed from `.end(callback)` to returning
+  // a promise in:
+  // https://github.com/webdriverio/webdriverio/blob/v3.0.0/lib/commands/end.js
+  this._selClient.end()
+    .then(function (results) {
+      self.log("[end]", JSON.stringify(results || {}).grey);
+
+      // Ignore selenium HTTP errors.
+      callback();
+    })
+    // Catch real programmatic errors.
+    .catch(callback);
 };
 
 /**


### PR DESCRIPTION
This is one of those "I have no idea how it ever worked before"-type bugs...

The api for modern `webdriverio` simply just ignores callbacks and returns a promise instead. We now require modern and use it properly.

/cc @Maciek416 @coopy @kkerr1