### PR TITLE
Use the phantomjs-prebuilt module instead of phantomjs(deprecated)

### DIFF
--- a/config.js
+++ b/config.js
@@ -27,7 +27,7 @@ var path = require("path");
 // Infer Phantom path off NPM module if available.
 var PHANTOM_PATH = false;
 try {
-  PHANTOM_PATH = require("phantomjs").path; // eslint-disable-line global-require
+  PHANTOM_PATH = require("phantomjs-prebuilt").path; // eslint-disable-line global-require
 } catch (err) {
   // Leave false.
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-filenames": "^0.2.0",
     "guacamole": "^1.1.2",
     "mocha": "^2.2.4",
-    "phantomjs": "^1.9.16",
+    "phantomjs-prebuilt": "^2.1.5",
     "saucelabs": "^0.1.1",
     "selenium-standalone": "4.7.2",
     "wd": "^0.3.11",


### PR DESCRIPTION
The `phantomjs` npm module has been deprecated in favor of `phantomjs-prebuilt`.